### PR TITLE
Fedora support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ all:
  
 install:
 	@cd src && make
-	@addgroup --system ${GROUP} 2>/dev/null
+	@addgroup --system ${GROUP} 2>/dev/null || groupadd -f --system autosshfs 2> /dev/null
 	@install -o root -g root     -m 0750 src/autosshfs-user ${PREFIX}/sbin/
 	@install -o root -g ${GROUP} -m 0750 src/autosshfs-map  ${PREFIX}/sbin/
 	@install -o root -g ${GROUP} -m 0750 src/autosshfs-ssh  ${PREFIX}/sbin/
@@ -25,7 +25,7 @@ install:
 
 uninstall:
 	@rm -rf ${PREFIX}/sbin/autosshfs-* ${PREFIX}/bin/autosshfs-as-* ${PREFIX}/bin/keychain-ring ${PREFIX}/share/doc/autosshfs
-	@delgroup ${GROUP} 2>/dev/null
+	@delgroup ${GROUP} 2>/dev/null || groupdel autosshfs
 	@cd src && make clean
 
 license:

--- a/README.org
+++ b/README.org
@@ -30,10 +30,17 @@
 
 * Quick Install
 
+On Ubuntu/Debian:
 :    sudo apt-get install keychain ssh-askpass sshfs autofs
 :    git clone https://github.com/hellekin/autosshfs.git
 :    cd autosshfs && sudo make install
 :    sudo autosshfs-user add $(id -un)
+
+On Fedora:
+:    su -c "yum install openssh sshfs autofs keychain openssh-askpass"
+:    su -c "systemctl start autofs; systemctl enable autofs"
+:    git clone https://github.com/hellekin/autosshfs.git && cd autosshfs
+:    su -c "make install && autosshfs-user add $(id -un)"
 
      If you don't already have an SSH key, create one now
 

--- a/src/autosshfs-user.in
+++ b/src/autosshfs-user.in
@@ -108,4 +108,4 @@ case "$1" in
     ;;
 esac
 
-restart autofs 2>/dev/null || /etc/init.d/autofs restart
+restart autofs 2>/dev/null || /etc/init.d/autofs restart 2>/dev/null || systemctl autofs restart 2>/dev/null

--- a/src/autosshfs-user.in
+++ b/src/autosshfs-user.in
@@ -88,7 +88,7 @@ EOD
 
 case "$1" in
   add)
-    adduser $username $GROUP
+    gpasswd -a $username $GROUP
     create_ssh_wrapper
     if grep "^$mountroot" /etc/auto.master 2>/dev/null
     then
@@ -99,7 +99,7 @@ case "$1" in
     ;;
   del)
     rm -f $SSH_WRAPPER
-    deluser $username $GROUP
+    gpasswd -d $username $GROUP
     sed -e "s#${mountroot}.*##" -i /etc/auto.master
     ;;
   *)


### PR DESCRIPTION
Inspired by @korakinos Arch Linux support. I have done the necessary to get the scripts working under Fedora Linux. I have tried to make my changes fit with those he proposed for Arch Linux support to ease merging (e.g. use `gpasswd` instead of `adduser`).

I have plenty of colleagues at work using Fedora, but haven't been able to heartily recommend autosshfs due to the modifications required. No longer :-)
- I have tested this branch with Fedora 19 (beta)
- The changes should not cause a regression in the Debian/Ubuntu behaviour.
